### PR TITLE
Adding new features from systemd.time

### DIFF
--- a/pkg/systemdtime/systemdtime.go
+++ b/pkg/systemdtime/systemdtime.go
@@ -1,6 +1,7 @@
 package systemdtime
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -69,6 +70,8 @@ func ParseDuration(raw string) (time.Duration, error) {
 		return 0, fmt.Errorf("ParseDuration: incorrect format for raw input %s", raw)
 	}
 
+	isAgo := strings.Contains(raw, "ago")
+
 	reNegative, err := regexp.Compile(`^\s*-.*`)
 	if err != nil {
 		return 0, err
@@ -114,7 +117,27 @@ func ParseDuration(raw string) (time.Duration, error) {
 		totalDuration *= -1
 	}
 
+	if isAgo {
+		totalDuration *= -1
+	}
+
 	return totalDuration, nil
+}
+
+func TranslateWords(raw string) (time.Time, error) {
+	switch raw {
+	case "now":
+		return time.Now(), nil
+	case "today":
+		return time.Now().Truncate(time.Hour * 24), nil
+	case "yesterday":
+		return time.Now().Add(time.Hour * -24).Truncate(time.Hour * 24), nil
+	case "tomorrow":
+		return time.Now().Add(time.Hour * 24).Truncate(time.Hour * 24), nil
+	default:
+		var t time.Time
+		return t, errors.New("no matching words")
+	}
 }
 
 // AdjustTime takes a systemd time adjustment string and uses it to modify a time.Time

--- a/pkg/systemdtime/systemdtime_test.go
+++ b/pkg/systemdtime/systemdtime_test.go
@@ -107,7 +107,11 @@ func TestToDuration(t *testing.T) {
 		" 2 min 23sec": 2*time.Minute + 23*time.Second,
 		"1sec":         1 * time.Second,
 		"1 hour":       1 * time.Hour,
+		"-1hour":       -1 * time.Hour,
+		"-1hour ago":   1 * time.Hour,
 		"-2day":        -2 * 24 * time.Hour,
+		"2day ago":     -2 * 24 * time.Hour,
+		"-2day ago":    2 * 24 * time.Hour,
 		"10 minutes":   10 * time.Minute,
 	}
 
@@ -121,6 +125,26 @@ func TestToDuration(t *testing.T) {
 			t.Errorf("Duration %d is not equal to output %d", duration, output)
 		}
 	}
+}
+
+func TestTranslatedWords(t *testing.T) {
+	testWord := func(t *testing.T, raw string, shouldSucceed time.Time) {
+		got, err := TranslateWords(raw)
+		if raw == "now" {
+			got = got.Truncate(time.Second)
+		}
+		if err != nil {
+			t.Fatalf("Input '%s' failed: err is '%v', and shouldSucceed set to %v", raw, err, shouldSucceed)
+		}
+		if !got.Equal(shouldSucceed) {
+			t.Fatalf("Input '%s' failed: got %v, and shouldSucceed set to %v", raw, got, shouldSucceed)
+		}
+	}
+
+	testWord(t, "now", time.Now().Truncate(time.Second))
+	testWord(t, "today", time.Now().Truncate(time.Hour*24))
+	testWord(t, "yesterday", time.Now().Add(time.Hour*-24).Truncate(time.Hour*24))
+	testWord(t, "tomorrow", time.Now().Add(time.Hour*24).Truncate(time.Hour*24))
 }
 
 func TestAdjustTime(t *testing.T) {


### PR DESCRIPTION
Adding the `ago` keywords to Adjustedtime.
Add a new function that will translate common keywords `now`, `today`, `tomorrow`, `yesterday`.
Lower case first letter on error to comply with `staticcheck` linter.